### PR TITLE
fix: ts argument type on fake and restore methods

### DIFF
--- a/adonis-typings/drive.ts
+++ b/adonis-typings/drive.ts
@@ -395,12 +395,12 @@ declare module '@ioc:Adonis/Core/Drive' {
     /**
      * Fake the default or a named disk
      */
-    fake(disk?: keyof DisksList | keyof DisksList[]): FakeDriveContract
+    fake(disk?: keyof DisksList | (keyof DisksList)[]): FakeDriveContract
 
     /**
      * Restore fake for the default or a named disk
      */
-    restore(disk?: keyof DisksList | keyof DisksList[]): void
+    restore(disk?: keyof DisksList | (keyof DisksList)[]): void
 
     /**
      * Restore all fakes

--- a/src/DriveManager/index.ts
+++ b/src/DriveManager/index.ts
@@ -128,7 +128,7 @@ export class DriveManager
   /**
    * Fake default or a named disk
    */
-  public fake(disks?: keyof DisksList | keyof DisksList[]) {
+  public fake(disks?: keyof DisksList | (keyof DisksList)[]) {
     disks = disks || this.getDefaultMappingName()
     const disksToFake = Array.isArray(disks) ? disks : [disks]
 
@@ -145,7 +145,7 @@ export class DriveManager
   /**
    * Restore the fake for the default or a named disk
    */
-  public restore(disks?: keyof DisksList | keyof DisksList[]) {
+  public restore(disks?: keyof DisksList | (keyof DisksList)[]) {
     disks = disks || this.getDefaultMappingName()
     const disksToRestore = Array.isArray(disks) ? disks : [disks]
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

According to the [documentation](https://docs.adonisjs.com/guides/testing/fakes#drive), we can fake and restore multiple drives by passing an array as parameter, but the function definition was incorrect. https://github.com/adonisjs/drive/issues/45

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/drive/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

