### PR TITLE
fix(pathprefixer): correctly prefix root (./) directory

### DIFF
--- a/src/PathPrefixer/index.ts
+++ b/src/PathPrefixer/index.ts
@@ -77,7 +77,8 @@ export class PathPrefixer {
    * Useful for cloud drivers prefix when listitng files.
    */
   public prefixDirectoryPath(location: string): string {
-    return this.prefixPath(location) + this.separator
+    const prefixed = this.prefixPath(location)
+    return prefixed === this.prefix ? prefixed : prefixed + this.separator
   }
 
   /**

--- a/test/path-prefixer.spec.ts
+++ b/test/path-prefixer.spec.ts
@@ -90,6 +90,11 @@ test.group('Path prefixer | prefixDirectoryPath', () => {
       { prefix: '/dir', path: '/subdir', expected: '/dir/subdir/' },
       { prefix: '', path: 'dir', expected: 'dir/' },
       { prefix: '', path: 'with-slash/', expected: 'with-slash/' },
+      { prefix: '', path: '.', expected: '' },
+      { prefix: '', path: '/', expected: '' },
+      { prefix: '', path: './', expected: '' },
+      { prefix: '/', path: '.', expected: '/' },
+      { prefix: 'prefix', path: '.', expected: 'prefix/' },
     ])
     .run(async ({ assert }, { prefix, path, expected }) => {
       const prefixer = new PathPrefixer(prefix)


### PR DESCRIPTION
## Proposed changes

Fix case when using `PathPrefixer.prefixDirectoryPath` for list with s3 and gcs.
When passing root directory `.`, `/` or `./` we should return empty prefix `''`.
Added tests for failing cases before this change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/drive/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments
Prerequisite for correctly working list for s3 and gcs drivers (I will create PRs).

