### PR TITLE
fix: handle writeOptions when diskNameOrOptions is provided

### DIFF
--- a/providers/drive_provider.ts
+++ b/providers/drive_provider.ts
@@ -125,6 +125,7 @@ export default class DriveProvider {
 
         if (typeof diskNameOrOptions === 'string') {
           diskName = diskNameOrOptions
+          options = writeOptions ?? undefined
         } else if (diskNameOrOptions && !writeOptions) {
           options = diskNameOrOptions
         } else if (writeOptions) {


### PR DESCRIPTION
### 🔗 Linked issue

#54 

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed the `moveToDisk` function of the MultipartFile helper to correctly handle `writeOptions` when `diskNameOrOptions` is provided, ensuring that `writeOptions` are no longer ignored. 
Resolves #54 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
